### PR TITLE
Export KituraBuddy for use in Swift PM applications

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,12 @@ import PackageDescription
 
 let package = Package(
     name: "KituraBuddy",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "KituraBuddy",
+            targets: ["KituraBuddy"]),
+    ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/IBM-Swift/SwiftyRequest.git", .upToNextMinor(from: "0.0.5")),


### PR DESCRIPTION
Export KituraBuddy as a product/library so that it can be used in Swift PM based applications.